### PR TITLE
Use document prefixes per collection

### DIFF
--- a/src/IdentityServer4.RavenDB.Storage/Entities/ApiResource.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/ApiResource.cs
@@ -12,5 +12,7 @@ namespace IdentityServer4.RavenDB.Storage.Entities
         public DateTime? Updated { get; set; }
         public DateTime? LastAccessed { get; set; }
         public bool NonEditable { get; set; }
+
+        protected override string FormatDocumentId(string name) => "ApiResources/" + name;
     }
 }

--- a/src/IdentityServer4.RavenDB.Storage/Entities/ApiScope.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/ApiScope.cs
@@ -4,5 +4,7 @@
     {
         public bool Required { get; set; }
         public bool Emphasize { get; set; }
+
+        protected override string FormatDocumentId(string name) => "ApiScopes/" + name;
     }
 }

--- a/src/IdentityServer4.RavenDB.Storage/Entities/Client.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/Client.cs
@@ -6,13 +6,18 @@ namespace IdentityServer4.RavenDB.Storage.Entities
 {
     public class Client
     {
+        private string clientId;
         public string Id { get; set; }
         public bool Enabled { get; set; } = true;
 
         public string ClientId
         {
-            get => Id;
-            set => Id = value;
+            get => clientId;
+            set
+            {
+                clientId = value;
+                Id = "Clients/" + value;
+            }
         }
 
         public string ProtocolType { get; set; } = "oidc";

--- a/src/IdentityServer4.RavenDB.Storage/Entities/IdentityResource.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/IdentityResource.cs
@@ -13,5 +13,7 @@ namespace IdentityServer4.RavenDB.Storage.Entities
         public DateTime? Updated { get; set; }
 
         public bool NonEditable { get; set; }
+
+        protected override string FormatDocumentId(string name) => "IdentityResources/" + name;
     }
 }

--- a/src/IdentityServer4.RavenDB.Storage/Entities/Resource.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/Resource.cs
@@ -9,16 +9,25 @@ namespace IdentityServer4.RavenDB.Storage.Entities
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public abstract class Resource
     {
+        private string name;
+
         private string DebuggerDisplay => Name ?? $"{{{typeof(Resource)}}}";
 
-        public string Id { get; set; }
+        public string Id { get; private set; }
+
         public bool Enabled { get; set; } = true;
 
         public string Name
         {
-            get => Id;
-            set => Id = value;
+            get => name;
+            set
+            {
+                Id = FormatDocumentId(value);
+                name = value;
+            }
         }
+
+        protected abstract string FormatDocumentId(string name);
 
         public string DisplayName { get; set; }
         public string Description { get; set; }

--- a/src/IdentityServer4.RavenDB.Storage/Indexes/ApiScopeIndex.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Indexes/ApiScopeIndex.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using IdentityServer4.RavenDB.Storage.Entities;
+using Raven.Client.Documents.Indexes;
+
+namespace IdentityServer4.RavenDB.Storage.Indexes
+{
+    public class ApiScopeIndex : AbstractIndexCreationTask<ApiScope, ApiScopeIndex.Result>
+    {
+        public class Result
+        {
+            public string Name { get; set; }
+        }
+
+        public ApiScopeIndex()
+        {
+            Map = apiScopes => from apiScope in apiScopes
+                select new Result
+                {
+                    Name = apiScope.Name
+                };
+        }
+    }
+}

--- a/src/IdentityServer4.RavenDB.Storage/Stores/ClientStore.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Stores/ClientStore.cs
@@ -29,7 +29,9 @@ namespace IdentityServer4.RavenDB.Storage.Stores
         /// <inheritdoc />
         public virtual async Task<Client> FindClientByIdAsync(string clientId)
         {
-            var client = await Session.LoadAsync<Entities.Client>(clientId);
+            var client = await Session.Query<Entities.Client, ClientIndex>()
+                .Where(x => x.ClientId == clientId)
+                .SingleOrDefaultAsync();
 
             if (client == null) return null;
 

--- a/src/IdentityServer4.RavenDB.Storage/Stores/ResourceStore.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Stores/ResourceStore.cs
@@ -35,9 +35,11 @@ namespace IdentityServer4.RavenDB.Storage.Stores
         {
             if (scopeNames == null) throw new ArgumentNullException(nameof(scopeNames));
 
-            var identityResources = await Session.LoadAsync<Entities.IdentityResource>(scopeNames);
+            var identityResources = await Session.Query<Entities.IdentityResource, IdentityResourceIndex>()
+                .Where(x => x.Name.In(scopeNames))
+                .ToArrayAsync();
 
-            IdentityResource[] result = identityResources.Values.Select(x => x.ToModel()).ToArray();
+            IdentityResource[] result = identityResources.Select(x => x.ToModel()).ToArray();
 
             if (result.Any())
             {
@@ -56,9 +58,11 @@ namespace IdentityServer4.RavenDB.Storage.Stores
         {
             if (scopeNames == null) throw new ArgumentNullException(nameof(scopeNames));
 
-            var scopes = await Session.LoadAsync<Entities.ApiScope>(scopeNames);
+            var scopes = await Session.Query<Entities.ApiScope, ApiScopeIndex>()
+                .Where(x => x.Name.In(scopeNames))
+                .ToArrayAsync();
 
-            ApiScope[] result = scopes.Values.Select(x => x.ToModel()).ToArray();
+            ApiScope[] result = scopes.Select(x => x.ToModel()).ToArray();
 
             if (result.Any())
             {
@@ -77,10 +81,11 @@ namespace IdentityServer4.RavenDB.Storage.Stores
         {
             if (scopeNames == null) throw new ArgumentNullException(nameof(scopeNames));
 
-            var query = Session.Query<Entities.ApiResource, ApiResourceIndex>()
-                    .Where(apiResource => apiResource.Scopes.ContainsAny(scopeNames));
+            var apiResources = await Session.Query<Entities.ApiResource, ApiResourceIndex>()
+                    .Where(apiResource => apiResource.Scopes.ContainsAny(scopeNames))
+                    .ToArrayAsync();
 
-            var result = (await query.ToArrayAsync()).Select(x => x.ToModel()).ToArray();
+            var result = apiResources.Select(x => x.ToModel()).ToArray();
 
             if (result.Any())
             {
@@ -99,9 +104,11 @@ namespace IdentityServer4.RavenDB.Storage.Stores
         {
             if (apiResourceNames == null) throw new ArgumentNullException(nameof(apiResourceNames));
 
-            var apiResources = await Session.LoadAsync<Entities.ApiResource>(apiResourceNames);
+            var apiResources = await Session.Query<Entities.ApiResource, ApiResourceIndex>()
+                .Where(x => x.Name.In(apiResourceNames))
+                .ToArrayAsync();
 
-            ApiResource[] result = apiResources.Values.Select(x => x.ToModel()).ToArray();
+            ApiResource[] result = apiResources.Select(x => x.ToModel()).ToArray();
 
             if (result.Any())
             {

--- a/test/IdentityServer4.RavenDB.IntegrationTests/Stores/ResourceStoreTests.cs
+++ b/test/IdentityServer4.RavenDB.IntegrationTests/Stores/ResourceStoreTests.cs
@@ -70,14 +70,19 @@ namespace IdentityServer4.RavenDB.IntegrationTests.Stores
                 session.Store(resource.ToEntity());
                 session.SaveChanges();
             }
-            
+
             WaitForIndexing(ravenStore);
 
             ApiResource foundResource;
             using (var session = ravenStore.OpenAsyncSession())
             {
                 var store = new ResourceStore(session, FakeLogger<ResourceStore>.Create());
-                foundResource = (await store.FindApiResourcesByNameAsync(new[] {resource.Name})).SingleOrDefault();
+                var apiResourceNames = new[]
+                {
+                    resource.Name,
+                    "non-existent"
+                };
+                foundResource = (await store.FindApiResourcesByNameAsync(apiResourceNames)).SingleOrDefault();
             }
 
             Assert.NotNull(foundResource);
@@ -105,7 +110,7 @@ namespace IdentityServer4.RavenDB.IntegrationTests.Stores
                 session.Store(CreateApiResourceTestResource().ToEntity());
                 session.SaveChanges();
             }
-            
+
             WaitForIndexing(ravenStore);
 
             ApiResource foundResource;
@@ -126,6 +131,7 @@ namespace IdentityServer4.RavenDB.IntegrationTests.Stores
             Assert.NotEmpty(foundResource.Scopes);
         }
 
+
         [Fact]
         public async Task FindApiResourcesByScopeNameAsync_WhenResourcesExist_ExpectResourcesReturned()
         {
@@ -142,7 +148,7 @@ namespace IdentityServer4.RavenDB.IntegrationTests.Stores
                 //session.Store(testApiScope.ToEntity());
                 session.SaveChanges();
             }
-            
+
             WaitForIndexing(ravenStore);
 
             IEnumerable<ApiResource> resources;
@@ -181,7 +187,7 @@ namespace IdentityServer4.RavenDB.IntegrationTests.Stores
                 //session.Store(CreateApiScopeTestResource().ToEntity());
                 session.SaveChanges();
             }
-            
+
             WaitForIndexing(ravenStore);
 
             IEnumerable<ApiResource> resources;
@@ -209,7 +215,7 @@ namespace IdentityServer4.RavenDB.IntegrationTests.Stores
                 session.Store(resource.ToEntity());
                 session.SaveChanges();
             }
-            
+
             WaitForIndexing(ravenStore);
 
             IList<IdentityResource> resources;
@@ -218,7 +224,8 @@ namespace IdentityServer4.RavenDB.IntegrationTests.Stores
                 var store = new ResourceStore(session, FakeLogger<ResourceStore>.Create());
                 resources = (await store.FindIdentityResourcesByScopeNameAsync(new List<string>
                 {
-                    resource.Name
+                    resource.Name,
+                    "non-existent"
                 })).ToList();
             }
 
@@ -245,7 +252,7 @@ namespace IdentityServer4.RavenDB.IntegrationTests.Stores
                 session.Store(CreateIdentityTestResource().ToEntity());
                 session.SaveChanges();
             }
-            
+
             WaitForIndexing(ravenStore);
 
             IList<IdentityResource> resources;
@@ -263,68 +270,73 @@ namespace IdentityServer4.RavenDB.IntegrationTests.Stores
             Assert.NotNull(resources.Single(x => x.Name == resource.Name));
         }
 
+
         [Fact]
         public async Task FindApiScopesByNameAsync_WhenResourceExists_ExpectResourceAndCollectionsReturned()
         {
             using var ravenStore = GetDocumentStore();
-            await new ApiResourceIndex().ExecuteAsync(ravenStore);
+            await new ApiScopeIndex().ExecuteAsync(ravenStore);
 
             var resource = CreateApiScopeTestResource();
 
             using (var session = ravenStore.OpenSession())
             {
-                //session.Store(resource.ToEntity());
+                session.Store(resource.ToEntity());
                 session.SaveChanges();
             }
+
+            WaitForIndexing(ravenStore);
 
             IList<ApiScope> resources;
             using (var session = ravenStore.OpenAsyncSession())
             {
                 var store = new ResourceStore(session, FakeLogger<ResourceStore>.Create());
-                //resources = (await store.FindApiScopesByNameAsync(new List<string>
-                //{
-                //    resource.Name
-                //})).ToList();
+                resources = (await store.FindApiScopesByNameAsync(new List<string>
+                {
+                    resource.Name,
+                    "non-existent"
+                })).ToList();
             }
 
-            //Assert.NotNull(resources);
-            //Assert.NotEmpty(resources);
-            //var foundScope = resources.Single();
+            Assert.NotNull(resources);
+            Assert.NotEmpty(resources);
+            var foundScope = resources.Single();
 
-            //Assert.Equal(resource.Name, foundScope.Name);
-            //Assert.NotNull(foundScope.UserClaims);
-            //Assert.NotEmpty(foundScope.UserClaims);
+            Assert.Equal(resource.Name, foundScope.Name);
+            Assert.NotNull(foundScope.UserClaims);
+            Assert.NotEmpty(foundScope.UserClaims);
         }
-
 
         [Fact]
         public async Task FindApiScopesByNameAsync_WhenResourcesExist_ExpectOnlyRequestedReturned()
         {
             using var ravenStore = GetDocumentStore();
-            await new ApiResourceIndex().ExecuteAsync(ravenStore);
-            
+            await new ApiScopeIndex().ExecuteAsync(ravenStore);
             var resource = CreateApiScopeTestResource();
 
             using (var session = ravenStore.OpenSession())
             {
-                //session.Store(resource.ToEntity());
-                //session.Store(CreateApiScopeTestResource().ToEntity());
+                session.Store(resource.ToEntity());
+                session.Store(CreateApiScopeTestResource().ToEntity());
                 session.SaveChanges();
             }
+
+            WaitForIndexing(ravenStore);
 
             IList<ApiScope> resources;
             using (var session = ravenStore.OpenAsyncSession())
             {
                 var store = new ResourceStore(session, FakeLogger<ResourceStore>.Create());
-                //resources = (await store.FindApiScopesByNameAsync(new List<string>
-                //{
-                //    resource.Name
-                //})).ToList();
+                resources = (await store.FindApiScopesByNameAsync(new List<string>
+                {
+                    resource.Name,
+                    "non-existent"
+                })).ToList();
             }
 
-            //Assert.NotNull(resources);
-            //Assert.NotEmpty(resources);
-            //Assert.NotNull(resources.Single(x => x.Name == resource.Name));
+            Assert.NotNull(resources);
+            Assert.NotEmpty(resources);
+            Assert.NotNull(resources.Single(x => x.Name == resource.Name));
         }
 
         [Fact]


### PR DESCRIPTION
After trying out different scenarios with the current version after latest update I found some nasty corner cases. For example IdentityServer can try to load all things based on scopes which caused confusion between collections. This PR adds collection prefix for document ids and keeps the uniqueness via the name. Now it's possible also to name, say identity resource and client, with the same name.

Decided to go with index queries instead of direct loads for now. Added more test coverage to fill missing bits.