### PR TITLE
Add explicit index usage to PersistedGrantStore.RemoveAsync

### DIFF
--- a/src/IdentityServer4.RavenDB.Storage/Stores/PersistedGrantStore.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Stores/PersistedGrantStore.cs
@@ -90,7 +90,7 @@ namespace IdentityServer4.RavenDB.Storage.Stores
         /// <inheritdoc />
         public virtual async Task RemoveAsync(string key)
         {
-            var persistedGrant = await Session.Query<Entities.PersistedGrant>()
+            var persistedGrant = await Session.Query<Entities.PersistedGrant, PersistentGrantIndex>()
                 .FirstOrDefaultAsync(x => x.Key == key);
 
             if (persistedGrant != null)


### PR DESCRIPTION
This was missing and while I started using this instead of the in-memory version, an exception was thrown when dynamic indexes are forbidden in server settings.