### PR TITLE
Support existing document store and index creation behind toggle

### DIFF
--- a/src/IdentityServer4.RavenDB.Storage/DocumentStoreHolder/ConfigurationDocumentStoreHolder.cs
+++ b/src/IdentityServer4.RavenDB.Storage/DocumentStoreHolder/ConfigurationDocumentStoreHolder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using IdentityServer4.RavenDB.Storage.Helpers;
+﻿using IdentityServer4.RavenDB.Storage.Helpers;
 using IdentityServer4.RavenDB.Storage.Options;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
@@ -9,15 +8,23 @@ namespace IdentityServer4.RavenDB.Storage.DocumentStoreHolder
     internal class ConfigurationDocumentStoreHolder : IDocumentStoreHolder
     {
         private readonly IDocumentStore _documentStore;
-        
+
         public ConfigurationDocumentStoreHolder(RavenDbConfigurationStoreOptions options)
+            : this(DocumentStoreHelper.InitializeDocumentStore(options.ConfigureDocumentStore), options)
         {
-            _documentStore = DocumentStoreHelper.InitializeDocumentStore(options.ConfigureDocumentStore);
-            IndexHelper.ExecuteConfigurationStoreIndexes(_documentStore);
         }
-        
+
+        public ConfigurationDocumentStoreHolder(IDocumentStore documentStore, RavenDbConfigurationStoreOptions options)
+        {
+            _documentStore = documentStore;
+            if (options.CreateIndexes)
+            {
+                IndexHelper.ExecuteConfigurationStoreIndexes(_documentStore);
+            }
+        }
+
         public IDocumentStore IntegrationTest_GetDocumentStore() => _documentStore;
-        
+
         public IAsyncDocumentSession OpenAsyncSession() => _documentStore.OpenAsyncSession();
 
         public void Dispose()

--- a/src/IdentityServer4.RavenDB.Storage/DocumentStoreHolder/OperationalDocumentStoreHolder.cs
+++ b/src/IdentityServer4.RavenDB.Storage/DocumentStoreHolder/OperationalDocumentStoreHolder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using IdentityServer4.RavenDB.Storage.Helpers;
+﻿using IdentityServer4.RavenDB.Storage.Helpers;
 using IdentityServer4.RavenDB.Storage.Options;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
@@ -9,15 +8,23 @@ namespace IdentityServer4.RavenDB.Storage.DocumentStoreHolder
     internal class OperationalDocumentStoreHolder : IDocumentStoreHolder
     {
         private readonly IDocumentStore _documentStore;
-        
+
         public OperationalDocumentStoreHolder(RavenDbOperationalStoreOptions options)
+            : this(DocumentStoreHelper.InitializeDocumentStore(options.ConfigureDocumentStore), options)
         {
-            _documentStore = DocumentStoreHelper.InitializeDocumentStore(options.ConfigureDocumentStore);
-            IndexHelper.ExecuteOperationalStoreIndexes(_documentStore);
         }
-        
+
+        public OperationalDocumentStoreHolder(IDocumentStore documentStore, RavenDbOperationalStoreOptions options)
+        {
+            _documentStore = documentStore;
+            if (options.CreateIndexes)
+            {
+                IndexHelper.ExecuteOperationalStoreIndexes(_documentStore);
+            }
+        }
+
         public IDocumentStore IntegrationTest_GetDocumentStore() => _documentStore;
-        
+
         public IAsyncDocumentSession OpenAsyncSession() => _documentStore.OpenAsyncSession();
 
         public void Dispose()

--- a/src/IdentityServer4.RavenDB.Storage/Extensions/IdentityServerBuilderExtensions.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Extensions/IdentityServerBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace IdentityServer4.RavenDB.Storage.Extensions
             this IIdentityServerBuilder builder, Action<RavenDbConfigurationStoreOptions> configureStoreOptions)
         {
             builder.Services.AddConfigurationDocumentStoreHolder(configureStoreOptions);
-            
+
             builder.AddClientStore<ClientStore>();
             builder.AddResourceStore<ResourceStore>();
             builder.AddCorsPolicyService<CorsPolicyService>();
@@ -26,7 +26,7 @@ namespace IdentityServer4.RavenDB.Storage.Extensions
             this IIdentityServerBuilder builder)
         {
             CheckAddConfigurationStoreHolderWasCalled(builder.Services);
-            
+
             builder.AddInMemoryCaching();
 
             builder.AddClientStoreCache<ClientStore>();
@@ -39,7 +39,7 @@ namespace IdentityServer4.RavenDB.Storage.Extensions
         public static IIdentityServerBuilder AddRavenDbOperationalStore(this IIdentityServerBuilder builder, Action<RavenDbOperationalStoreOptions> configureStoreOptions)
         {
             builder.Services.AddOperationalDocumentStoreHolder(configureStoreOptions);
-            
+
             builder.AddPersistedGrantStore<PersistedGrantStore>();
             builder.AddDeviceFlowStore<DeviceFlowStore>();
             return builder;

--- a/src/IdentityServer4.RavenDB.Storage/Extensions/ServiceCollectionExtensions.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using IdentityServer4.RavenDB.Storage.DocumentStoreHolder;
 using IdentityServer4.RavenDB.Storage.Helpers;
 using IdentityServer4.RavenDB.Storage.Options;
 using Microsoft.Extensions.DependencyInjection;
+using Raven.Client.Documents;
 
 namespace IdentityServer4.RavenDB.Storage.Extensions
 {
@@ -11,17 +12,21 @@ namespace IdentityServer4.RavenDB.Storage.Extensions
         public static IServiceCollection AddConfigurationDocumentStoreHolder(this IServiceCollection services, Action<RavenDbConfigurationStoreOptions> configureStoreOptions)
         {
             var options = RavenDbStoreOptionsHelper.GetOptions(configureStoreOptions);
-            
-            services.AddSingleton(provider => new ConfigurationDocumentStoreHolder(options));
+
+            services.AddSingleton(provider => options.ResolveDocumentStoreFromServices
+                ? new ConfigurationDocumentStoreHolder(provider.GetRequiredService<IDocumentStore>(), options)
+                : new ConfigurationDocumentStoreHolder(options));
 
             return services;
         }
-        
+
         public static IServiceCollection AddOperationalDocumentStoreHolder(this IServiceCollection services, Action<RavenDbOperationalStoreOptions> configureStoreOptions)
         {
             var options = RavenDbStoreOptionsHelper.GetOptions(configureStoreOptions);
-            
-            services.AddSingleton(provider => new OperationalDocumentStoreHolder(options));
+
+            services.AddSingleton(provider => options.ResolveDocumentStoreFromServices
+                ? new OperationalDocumentStoreHolder(provider.GetRequiredService<IDocumentStore>(), options)
+                : new OperationalDocumentStoreHolder(options));
 
             return services;
         }

--- a/src/IdentityServer4.RavenDB.Storage/Options/RavenDbStoreOptions.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Options/RavenDbStoreOptions.cs
@@ -6,5 +6,7 @@ namespace IdentityServer4.RavenDB.Storage.Options
     public abstract class RavenDbStoreOptions
     {
         public Action<DocumentStore> ConfigureDocumentStore { get; set; }
+        public bool CreateIndexes { get; set; } = true;
+        public bool ResolveDocumentStoreFromServices { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds support to reuse an existing document store from service proivder (we configure it globally and share it with other services too) instead of creating a new document store. 

Also adding a toggle whether indexes should be deployed automatically - we have custom migrations (RavenMigrations) and the process also includes refreshing the indexes. We don't want indexes to refresh outside of deployment process.