### PR TITLE
Expose entities and mappers as public

### DIFF
--- a/Host/Host.csproj
+++ b/Host/Host.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="4.0.4" />
+    <PackageReference Include="IdentityServer4" Version="4.1.2" />
 
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="3.1.8" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />

--- a/src/IdentityServer4.RavenDB.Storage/Entities/ApiResource.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/ApiResource.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace IdentityServer4.RavenDB.Storage.Entities
 {
-    internal class ApiResource : Resource
+    public sealed class ApiResource : Resource
     {
         public string AllowedAccessTokenSigningAlgorithms { get; set; }
         public List<Secret> Secrets { get; set; }

--- a/src/IdentityServer4.RavenDB.Storage/Entities/ApiScope.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/ApiScope.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace IdentityServer4.RavenDB.Storage.Entities
 {
-    internal class ApiScope : Resource
+    public sealed class ApiScope : Resource
     {
         public bool Required { get; set; }
         public bool Emphasize { get; set; }

--- a/src/IdentityServer4.RavenDB.Storage/Entities/Client.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/Client.cs
@@ -4,7 +4,7 @@ using IdentityServer4.Models;
 
 namespace IdentityServer4.RavenDB.Storage.Entities
 {
-    internal class Client
+    public sealed class Client
     {
         private string clientId;
         public string Id { get; set; }

--- a/src/IdentityServer4.RavenDB.Storage/Entities/ClientClaim.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/ClientClaim.cs
@@ -2,7 +2,7 @@
 
 namespace IdentityServer4.RavenDB.Storage.Entities
 {
-    internal class ClientClaim
+    public sealed class ClientClaim
     {
         public string Type { get; set; }
 

--- a/src/IdentityServer4.RavenDB.Storage/Entities/IdentityResource.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/IdentityResource.cs
@@ -2,7 +2,7 @@
 
 namespace IdentityServer4.RavenDB.Storage.Entities
 {
-    internal class IdentityResource : Resource
+    public sealed class IdentityResource : Resource
     {
         public bool Required { get; set; }
 

--- a/src/IdentityServer4.RavenDB.Storage/Entities/PersistedGrant.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/PersistedGrant.cs
@@ -2,7 +2,7 @@
 
 namespace IdentityServer4.RavenDB.Storage.Entities
 {
-    internal class PersistedGrant
+    public sealed class PersistedGrant
     {
         public string Id { get; set; }
         

--- a/src/IdentityServer4.RavenDB.Storage/Entities/Property.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/Property.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace IdentityServer4.RavenDB.Storage.Entities
 {
-    internal class Property
+    public sealed class Property
     {
         public string Key { get; set; }
 

--- a/src/IdentityServer4.RavenDB.Storage/Entities/Resource.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/Resource.cs
@@ -7,7 +7,7 @@ namespace IdentityServer4.RavenDB.Storage.Entities
     /// Models the common data of API and identity resources.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal abstract class Resource
+    public abstract class Resource
     {
         private string name;
 

--- a/src/IdentityServer4.RavenDB.Storage/Entities/Secret.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Entities/Secret.cs
@@ -2,7 +2,7 @@
 
 namespace IdentityServer4.RavenDB.Storage.Entities
 {
-    internal class Secret
+    public sealed class Secret
     {
         public string Description { get; set; }
 

--- a/src/IdentityServer4.RavenDB.Storage/Helpers/CryptographyHelper.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Helpers/CryptographyHelper.cs
@@ -2,7 +2,7 @@
 
 namespace IdentityServer4.RavenDB.Storage.Helpers
 {
-    internal static class CryptographyHelper
+    public static class CryptographyHelper
     {
         public static string CreateHash(string value)
         {

--- a/src/IdentityServer4.RavenDB.Storage/Mappers/ApiResourceMappers.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Mappers/ApiResourceMappers.cs
@@ -3,10 +3,10 @@ using IdentityServer4.RavenDB.Storage.Entities;
 
 namespace IdentityServer4.RavenDB.Storage.Mappers
 {
-    internal static class ApiResourceMappers
+    public static class ApiResourceMappers
     {
         private static readonly IMapper _mapper;
-        
+
         static ApiResourceMappers()
         {
             _mapper = new MapperConfiguration(cfg => cfg.AddProfile<ApiResourceMapperProfile>())

--- a/src/IdentityServer4.RavenDB.Storage/Mappers/ClientMappers.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Mappers/ClientMappers.cs
@@ -2,10 +2,10 @@
 
 namespace IdentityServer4.RavenDB.Storage.Mappers
 {
-    internal static class ClientMappers
+    public static class ClientMappers
     {
         private static readonly IMapper _mapper;
-        
+
         static ClientMappers()
         {
             _mapper = new MapperConfiguration(cfg => cfg.AddProfile<ClientMapperProfile>())

--- a/src/IdentityServer4.RavenDB.Storage/Mappers/IdentityResourceMappers.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Mappers/IdentityResourceMappers.cs
@@ -6,10 +6,10 @@ namespace IdentityServer4.RavenDB.Storage.Mappers
     /// <summary>
     /// Extension methods to map to/from entity/model for identity resources.
     /// </summary>
-    internal static class IdentityResourceMappers
+    public static class IdentityResourceMappers
     {
         private static readonly IMapper _mapper;
-        
+
         static IdentityResourceMappers()
         {
             _mapper = new MapperConfiguration(cfg => cfg.AddProfile<IdentityResourceMapperProfile>())

--- a/src/IdentityServer4.RavenDB.Storage/Mappers/PersistedGrantMappers.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Mappers/PersistedGrantMappers.cs
@@ -6,10 +6,10 @@ namespace IdentityServer4.RavenDB.Storage.Mappers
     /// <summary>
     /// Extension methods to map to/from entity/model for persisted grants.
     /// </summary>
-    internal static class PersistedGrantMappers
+    public static class PersistedGrantMappers
     {
         private static readonly IMapper _mapper;
-        
+
         static PersistedGrantMappers()
         {
             _mapper = new MapperConfiguration(cfg => cfg.AddProfile<PersistedGrantMapperProfile>())

--- a/src/IdentityServer4.RavenDB.Storage/Mappers/ScopeMappers.cs
+++ b/src/IdentityServer4.RavenDB.Storage/Mappers/ScopeMappers.cs
@@ -6,10 +6,10 @@ namespace IdentityServer4.RavenDB.Storage.Mappers
     /// <summary>
     /// Extension methods to map to/from entity/model for scopes.
     /// </summary>
-    internal static class ScopeMappers
+    public static class ScopeMappers
     {
         private static readonly IMapper _mapper;
-        
+
         static ScopeMappers()
         {
             _mapper = new MapperConfiguration(cfg => cfg.AddProfile<ScopeMapperProfile>())


### PR DESCRIPTION
Some things were internalized recently, but it makes it really had to seed data into database in testing and in migrations. With this PR I propose to open some types as public again (but sealed) to allow general data access and migrations by using existing types.

Basically entities and their mappers, allows manual data feeding in our solution.